### PR TITLE
removed redundant heading for Join Bangazon

### DIFF
--- a/Views/Customers/New.cshtml
+++ b/Views/Customers/New.cshtml
@@ -3,12 +3,11 @@
 @{
     ViewData["Title"] = "Join BangazonWeb";
 }
-
+<hr>
 <h2>@ViewData["Title"]</h2>
 
 <form asp-controller="Customers" asp-action="New" method="post">
     <div class="form-horizontal">
-        <h4>Join BangazonWeb</h4>
         <hr />
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
         <div class="form-group">


### PR DESCRIPTION
## Pull Request Description

Include the applicable information from the list below here 

1. Removed extra "Join Bangazon" heading on New Customer page.

## Steps to Test

Include the applicable information from the list below here

1. Go to New Customer
1. Verify that heading is not redundant and only appears once.

## Link to Feature Ticket

Provide the issue number that this pull request fixes
Example: #144 

